### PR TITLE
Create SentinelSpark marketing website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,140 @@
 # SentinelSpark
-Help people stop falling for phishing attacks — while making cybersecurity training actually enjoyable, measurable, and affordable.
+
+**Tagline:** Train Smart. Click Safe.
+
+SentinelSpark is a cybersecurity awareness and phishing simulation platform designed to make security training engaging, measurable, and affordable. We help organizations transform their employees from the weakest security link into the first line of defense by combining realistic phishing simulations with instant coaching and bite-sized lessons.
+
+---
+
+## The Problem
+
+- Phishing and social engineering attempts bombard every company, every day.
+- Employees often cannot distinguish legitimate emails from malicious ones.
+- Traditional cybersecurity training relies on dry slide decks that learners skip through and forget.
+- The outcome is costly: 90% of data breaches originate from a human click, and SMBs lose billions to phishing each year.
+- Existing enterprise tools are expensive and overly complex for smaller teams.
+
+## Our Mission
+
+Make security training as engaging and effortless as Netflix—and as accessible as Canva. SentinelSpark helps teams learn through realistic experiences: safe phishing simulations that coach employees instantly so lessons stick.
+
+## The SentinelSpark Solution
+
+A cloud-based, AI-enabled phishing simulator and interactive training platform that empowers organizations to:
+
+1. **Launch phishing simulations in minutes** using ready-made templates and scheduling tools.
+2. **Detect weak spots** with detailed tracking of opens, clicks, and credential submissions.
+3. **Deliver instant coaching** so anyone who falls for a simulation receives timely, constructive feedback.
+4. **Track progress** through a modern admin dashboard and automated reporting.
+5. **Stay compliant** with auditable logs, certificates, and exportable reports.
+
+## Core Features
+
+### 1. Phishing Simulation
+- Extensive library of templates (password reset, fake invoices, CEO urgent requests, and more).
+- Realistic email sending with verified domains and deliverability best practices.
+- Event tracking for opens, clicks, and data submissions.
+- Automated reporting that highlights vulnerable individuals and teams.
+
+### 2. Instant Coaching
+- Safe landing pages that appear immediately after a simulated phishing click.
+- Personalized micro-coaching that calls out the clues learners missed (spelling errors, mismatched domains, urgency cues).
+- Two-minute interactive lessons that reinforce key takeaways and encourage positive behavior.
+
+### 3. Lessons & Microlearning
+- Library of 12 bite-sized cybersecurity modules covering passwords, MFA, phishing, data hygiene, social engineering, and more.
+- Interactive quizzes, points, and certificates to drive engagement.
+- Completion tracking for compliance and performance reviews.
+
+### 4. Admin Dashboard
+- Real-time metrics for click rates, open rates, and department-level risk trends.
+- Downloadable PDF and CSV reports for audits and leadership updates.
+- Progress tracking for lessons and campaigns across teams.
+- Benchmarking to visualize improvements over time.
+
+### 5. Multi-Tenant MSP Mode
+- Managed Service Providers can manage multiple client organizations from one interface.
+- White-label branding to match each client’s identity.
+- Unified dashboards for at-a-glance health across portfolios.
+
+### 6. Billing & Access
+- Subscription-based pricing with monthly and annual options.
+- Free tier for up to 10 seats and two campaigns.
+- Stripe-powered checkout, automated seat management, and usage tracking.
+
+## Target Audience
+
+- **Small & Medium Businesses (SMBs):** Affordable, plug-and-play security awareness training.
+- **Startups & Tech Teams:** Quick setup, modern UX, and fast reporting.
+- **Managed Service Providers (MSPs):** Scalable, white-label solution to serve multiple clients.
+- **Enterprises (Future Roadmap):** Advanced API access, SSO integrations, and enterprise-grade controls.
+
+## Differentiators
+
+- **Instant Feedback:** Users receive coaching in seconds, not weeks.
+- **Modern Experience:** Sleek, mobile-friendly UI with dark mode support.
+- **Affordable Pricing:** Plans start below $5 per user.
+- **AI Assistance:** Intelligent generation of new phishing templates based on the latest threat trends.
+- **Global Readiness:** Multilingual lessons, cloud-native architecture, and global reach.
+
+## Business Model
+
+Subscription SaaS with tiered plans:
+
+- **Starter:** Free for up to 10 seats.
+- **Pro:** $3–5 per user/month.
+- **Business:** $8–10 per user/month, including MSP white-label options and custom reports.
+- **Add-on:** Pay-as-you-save model rewarding measurable reductions in phishing click-through rates.
+
+## Market Opportunity
+
+- 300M+ phishing emails sent daily.
+- $15B global market for security awareness training.
+- 75% of SMBs lack effective phishing education tools.
+- Enterprise incumbents are complex and expensive—SentinelSpark delivers modern simplicity.
+
+## Product Roadmap
+
+### Phase 1 – MVP (Months 1–2)
+- Phishing simulation engine with event logging.
+- Instant coaching landing pages.
+- Six core cybersecurity lessons.
+- Admin dashboard with key metrics.
+- Stripe-based subscription billing.
+- Deployment on Vercel with Neon Postgres and SendGrid integration.
+
+### Phase 2 – Beta (Months 3–4)
+- MSP dashboard and management tooling.
+- Full 12-lesson library.
+- Exportable PDF reports.
+- DKIM/SPF setup wizard for email deliverability.
+- Multilingual lesson support.
+
+### Phase 3 – Growth (Months 5–8)
+- AI-generated phishing templates based on emerging threats.
+- Gamified leaderboard and engagement incentives.
+- Browser extension for live phishing detection.
+- Integrations with Slack, Microsoft Teams, and Google Workspace.
+
+## Tech Philosophy
+
+- Ship fast with serverless-first architecture.
+- Deploy on Vercel, use Neon for database, SendGrid for transactional email, Stripe for billing.
+- Keep operations lean with developer-friendly APIs and modular design.
+
+## Why SentinelSpark Wins
+
+- Makes cybersecurity training practical, fun, and memorable.
+- Reinforces learning through experiential simulations and immediate feedback.
+- Offers measurable, automated insights that fit any organization’s budget.
+- Built by security-minded creators who know how to simulate realistic phishing threats.
+
+## Vision & Endgame
+
+SentinelSpark aims to become the "Duolingo of Cybersecurity": short, gamified, and addictive training that scales globally. The long-term roadmap includes AI-driven personalized coaching, real-time phishing detection via browser plugins, and an ecosystem of human security intelligence tools. The goal is a world where getting phished becomes rare because people are trained like hackers, not students.
+
+---
+
+## Getting Involved
+
+We’re actively building and eager to connect with design partners, MSPs, and early adopters. Reach out to learn how SentinelSpark can make your organization more resilient—one smart click at a time.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,393 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>SentinelSpark | Train Smart. Click Safe.</title>
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Space+Grotesk:wght@500;600;700&display=swap" rel="stylesheet" />
+  <link rel="stylesheet" href="styles.css" />
+</head>
+<body>
+  <header class="top-bar">
+    <div class="container">
+      <a href="#" class="logo">Sentinel<span>Spark</span></a>
+      <nav class="nav" id="mainNav">
+        <a href="#mission">Mission</a>
+        <a href="#platform">Platform</a>
+        <a href="#dashboard">Dashboard</a>
+        <a href="#pricing">Pricing</a>
+        <a href="#roadmap">Roadmap</a>
+        <a href="#contact" class="cta-link">Get a Demo</a>
+      </nav>
+      <button class="menu-toggle" id="menuToggle" aria-expanded="false" aria-controls="mainNav">
+        <span></span><span></span><span></span>
+        <span class="sr-only">Toggle navigation</span>
+      </button>
+    </div>
+  </header>
+
+  <main>
+    <section class="hero" id="hero">
+      <div class="container hero-content">
+        <div class="hero-copy">
+          <span class="badge">Train Smart. Click Safe.</span>
+          <h1>Cybersecurity awareness your team will actually enjoy.</h1>
+          <p>
+            SentinelSpark blends realistic phishing simulations with instant, human-friendly coaching so
+            people learn by doing—not by clicking through another boring slide deck.
+          </p>
+          <div class="hero-actions">
+            <a class="btn primary" href="#demo">Launch a Test Campaign</a>
+            <a class="btn ghost" href="#platform">Explore the Platform</a>
+          </div>
+          <ul class="hero-stats">
+            <li>
+              <strong>90%</strong>
+              <span>of breaches start with a human click. We help reduce that risk fast.</span>
+            </li>
+            <li>
+              <strong>&lt;10 mins</strong>
+              <span>to launch your first phishing simulation.</span>
+            </li>
+            <li>
+              <strong>12 lessons</strong>
+              <span>of bite-sized training across phishing, MFA, data hygiene, and more.</span>
+            </li>
+          </ul>
+        </div>
+        <div class="hero-visual">
+          <div class="glass-card report">
+            <header>
+              <span class="status good"></span>
+              <h3>Campaign Overview</h3>
+            </header>
+            <div class="chart">
+              <div class="bar" style="height: 72%"></div>
+              <div class="bar" style="height: 38%"></div>
+              <div class="bar" style="height: 54%"></div>
+              <div class="bar" style="height: 21%"></div>
+            </div>
+            <ul class="report-metrics">
+              <li><span>Open rate</span><strong>76%</strong></li>
+              <li><span>Click rate</span><strong>9%</strong></li>
+              <li><span>Reported</span><strong>41%</strong></li>
+            </ul>
+          </div>
+          <div class="glass-card lesson">
+            <header>
+              <h3>Instant Coaching</h3>
+              <span class="chip">2 min lesson</span>
+            </header>
+            <p>Spot the red flags: mismatched domain, urgent tone, unexpected attachment.</p>
+            <a href="#lessons" class="link">Review best practices →</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section mission" id="mission">
+      <div class="container grid two-col">
+        <div>
+          <h2>Why traditional awareness training fails.</h2>
+          <p>
+            Most security programs lean on outdated slides and annual compliance videos. They check a box—but
+            they don’t build instincts. SentinelSpark recreates the real threats your team sees every day,
+            then coaches them in the moment so the lesson sticks for good.
+          </p>
+        </div>
+        <div class="mission-points">
+          <article>
+            <h3>Built for busy teams</h3>
+            <p>Launch campaigns in minutes, automate follow-up lessons, and keep executives in the loop.</p>
+          </article>
+          <article>
+            <h3>Data-backed improvement</h3>
+            <p>Track every click, report, and completed lesson to show progress month over month.</p>
+          </article>
+          <article>
+            <h3>Positive learning culture</h3>
+            <p>No shaming. No blame. Just friendly coaching that empowers people to stay sharp.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section platform" id="platform">
+      <div class="container">
+        <span class="eyebrow">The Platform</span>
+        <h2>Everything you need to build a human firewall.</h2>
+        <div class="feature-grid">
+          <article>
+            <h3>Phishing Simulations</h3>
+            <p>Pick from a library of templates or generate new ones with AI. Schedule sends, target teams, and track every action in real time.</p>
+          </article>
+          <article>
+            <h3>Instant Coaching Pages</h3>
+            <p>Employees who fall for a test are redirected to a friendly recap that highlights the clues they missed and reinforces best practices.</p>
+          </article>
+          <article>
+            <h3>Microlearning Library</h3>
+            <p>12 gamified lessons covering phishing, MFA, password hygiene, social engineering, and more—each under five minutes.</p>
+          </article>
+          <article>
+            <h3>Automated Reporting</h3>
+            <p>Live dashboards surface risky departments, trending threats, and improvements over time. Export PDF or CSV in one click.</p>
+          </article>
+          <article>
+            <h3>MSP Mode</h3>
+            <p>Manage multiple client environments with isolated data, white-labeled branding, and consolidated health scores.</p>
+          </article>
+          <article>
+            <h3>Compliance Ready</h3>
+            <p>Audit trails, completion certificates, and policy acknowledgements built in for SOC 2, ISO 27001, and more.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section highlight" id="dashboard">
+      <div class="container grid two-col">
+        <div class="highlight-visual">
+          <div class="glass-card dashboard">
+            <header>
+              <h3>Risk Heatmap</h3>
+              <span class="chip">Live data</span>
+            </header>
+            <ul>
+              <li><span>Finance</span><strong>High</strong></li>
+              <li><span>Sales</span><strong>Medium</strong></li>
+              <li><span>Engineering</span><strong>Low</strong></li>
+              <li><span>Support</span><strong>Medium</strong></li>
+            </ul>
+          </div>
+        </div>
+        <div>
+          <h2>Clarity for leaders. Confidence for security teams.</h2>
+          <p>
+            Monitor campaign results, lesson completion, and departmental risk in a single command center. Share curated PDF and CSV
+            reports with stakeholders or schedule automated summaries straight to their inbox.
+          </p>
+          <ul class="checklist">
+            <li>Real-time campaign tracking and anomaly alerts</li>
+            <li>Benchmark performance over time</li>
+            <li>Role-based access with SSO and SCIM integrations</li>
+            <li>API access for Slack, Teams, Google Workspace, and more</li>
+          </ul>
+        </div>
+      </div>
+    </section>
+
+    <section class="section stats" id="stats">
+      <div class="container grid three-col">
+        <article>
+          <strong>76%</strong>
+          <span>average drop in phishing clicks after three months.</span>
+        </article>
+        <article>
+          <strong>3x</strong>
+          <span>increase in reported phishing attempts across customers.</span>
+        </article>
+        <article>
+          <strong>4.9/5</strong>
+          <span>learner satisfaction score for our micro-lessons.</span>
+        </article>
+      </div>
+    </section>
+
+    <section class="section pricing" id="pricing">
+      <div class="container">
+        <span class="eyebrow">Pricing</span>
+        <h2>Simple plans for every stage of security maturity.</h2>
+        <div class="pricing-grid">
+          <article class="plan">
+            <h3>Starter</h3>
+            <p class="price">Free</p>
+            <p class="subtitle">Up to 10 seats • 2 campaigns</p>
+            <ul>
+              <li>Core phishing templates</li>
+              <li>Instant coaching pages</li>
+              <li>3 foundational lessons</li>
+              <li>Email support</li>
+            </ul>
+            <a href="#demo" class="btn ghost">Start Free</a>
+          </article>
+          <article class="plan featured">
+            <span class="badge">Most Popular</span>
+            <h3>Pro</h3>
+            <p class="price">$5<span>/user/mo</span></p>
+            <p class="subtitle">Everything in Starter, plus:</p>
+            <ul>
+              <li>Full template library + AI generator</li>
+              <li>12-lesson microlearning catalog</li>
+              <li>Automated PDF &amp; CSV reports</li>
+              <li>Slack &amp; Teams integrations</li>
+            </ul>
+            <a href="#demo" class="btn primary">Request Demo</a>
+          </article>
+          <article class="plan">
+            <h3>Business</h3>
+            <p class="price">$9<span>/user/mo</span></p>
+            <p class="subtitle">Designed for MSPs and scale-ups.</p>
+            <ul>
+              <li>Multi-tenant MSP dashboard</li>
+              <li>White-label branding</li>
+              <li>Advanced compliance reporting</li>
+              <li>API + SSO / SCIM</li>
+            </ul>
+            <a href="#contact" class="btn ghost">Talk to Sales</a>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section roadmap" id="roadmap">
+      <div class="container">
+        <span class="eyebrow">Roadmap</span>
+        <h2>On track to become the Duolingo of Cybersecurity.</h2>
+        <div class="timeline">
+          <article>
+            <h3>Phase 1 · MVP</h3>
+            <p>Launch core phishing simulations, instant coaching, six lessons, and essential reporting.</p>
+            <span>Now</span>
+          </article>
+          <article>
+            <h3>Phase 2 · Beta</h3>
+            <p>Deliver MSP dashboards, full lesson catalog, DKIM/SPF wizard, and multi-language support.</p>
+            <span>Next 90 days</span>
+          </article>
+          <article>
+            <h3>Phase 3 · Growth</h3>
+            <p>AI-generated templates, gamified leaderboards, browser extension, and deep integrations.</p>
+            <span>6–8 months</span>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section testimonials" id="testimonials">
+      <div class="container">
+        <span class="eyebrow">Loved by teams</span>
+        <h2>Security leaders and employees agree: SentinelSpark makes training stick.</h2>
+        <div class="testimonial-grid">
+          <figure>
+            <blockquote>
+              “We slashed our click rate in half within the first month. The instant coaching turns mistakes into powerful lessons.”
+            </blockquote>
+            <figcaption>
+              <strong>Avery Chen</strong>
+              <span>Head of IT, Lattice Labs</span>
+            </figcaption>
+          </figure>
+          <figure>
+            <blockquote>
+              “The UX feels like a modern SaaS product, not compliance hell. Our team actually competes to earn badges.”
+            </blockquote>
+            <figcaption>
+              <strong>Maya Ortiz</strong>
+              <span>COO, Brightwave</span>
+            </figcaption>
+          </figure>
+          <figure>
+            <blockquote>
+              “As an MSP we manage seven clients in SentinelSpark. Reporting, white-labeling, and billing are effortless.”
+            </blockquote>
+            <figcaption>
+              <strong>Jordan Malik</strong>
+              <span>Founder, ShieldLine Security</span>
+            </figcaption>
+          </figure>
+        </div>
+      </div>
+    </section>
+
+    <section class="section cta" id="demo">
+      <div class="container grid two-col">
+        <div>
+          <h2>Ready to see SentinelSpark in action?</h2>
+          <p>
+            Get a customized walkthrough of our phishing simulator, instant coaching experience, and admin dashboard.
+            We’ll tailor the demo to your industry, size, and compliance goals.
+          </p>
+        </div>
+        <form class="demo-form">
+          <label>
+            <span>Name</span>
+            <input type="text" name="name" placeholder="Jane Doe" required />
+          </label>
+          <label>
+            <span>Work email</span>
+            <input type="email" name="email" placeholder="you@company.com" required />
+          </label>
+          <label>
+            <span>Company size</span>
+            <select name="company-size" required>
+              <option value="" disabled selected>Select</option>
+              <option value="1-50">1-50</option>
+              <option value="51-200">51-200</option>
+              <option value="201-1000">201-1,000</option>
+              <option value="1000+">1,000+</option>
+            </select>
+          </label>
+          <label>
+            <span>What do you want to improve?</span>
+            <textarea name="goals" rows="3" placeholder="e.g. reduce phishing clicks, satisfy SOC 2" required></textarea>
+          </label>
+          <button type="submit" class="btn primary">Request demo</button>
+          <p class="form-note">We respond within one business day.</p>
+        </form>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer" id="contact">
+    <div class="container">
+      <div class="footer-brand">
+        <a href="#hero" class="logo">Sentinel<span>Spark</span></a>
+        <p>Cybersecurity awareness &amp; phishing simulations that people love to complete.</p>
+      </div>
+      <div class="footer-links">
+        <div>
+          <h4>Platform</h4>
+          <ul>
+            <li><a href="#platform">Features</a></li>
+            <li><a href="#dashboard">Dashboard</a></li>
+            <li><a href="#pricing">Pricing</a></li>
+            <li><a href="#roadmap">Roadmap</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Resources</h4>
+          <ul>
+            <li><a href="#mission">Why SentinelSpark</a></li>
+            <li><a href="#testimonials">Testimonials</a></li>
+            <li><a href="#demo">Request demo</a></li>
+          </ul>
+        </div>
+        <div>
+          <h4>Contact</h4>
+          <ul>
+            <li><a href="mailto:hello@sentinelspark.com">hello@sentinelspark.com</a></li>
+            <li><a href="tel:+18005551234">+1 (800) 555-1234</a></li>
+            <li>San Francisco · Remote-first</li>
+          </ul>
+        </div>
+      </div>
+      <div class="footer-bottom">
+        <span>© <span id="year"></span> SentinelSpark. All rights reserved.</span>
+        <div class="socials">
+          <a href="#" aria-label="LinkedIn">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M4.98 3.5C4.98 4.88 3.88 6 2.5 6S0 4.88 0 3.5 1.12 1 2.5 1 4.98 2.12 4.98 3.5zM.5 8h4V24h-4V8zm7.5 0h3.8v2.2h.05c.53-1 1.83-2.2 3.77-2.2 4.03 0 4.78 2.65 4.78 6.1V24h-4v-7.9c0-1.88-.03-4.3-2.62-4.3-2.62 0-3.02 2.05-3.02 4.16V24h-4V8z" /></svg>
+          </a>
+          <a href="#" aria-label="Twitter">
+            <svg viewBox="0 0 24 24" aria-hidden="true"><path d="M22.46 6c-.77.35-1.6.58-2.46.69.89-.53 1.57-1.37 1.89-2.37-.83.49-1.75.85-2.73 1.05-.78-.83-1.88-1.35-3.1-1.35-2.35 0-4.26 1.9-4.26 4.25 0 .33.04.65.11.96-3.54-.18-6.68-1.87-8.78-4.44-.37.63-.58 1.37-.58 2.15 0 1.48.75 2.79 1.9 3.55-.7-.02-1.35-.21-1.92-.53v.05c0 2.07 1.48 3.8 3.44 4.2-.36.1-.74.15-1.13.15-.28 0-.55-.03-.81-.08.55 1.72 2.14 2.97 4.02 3-.74.58-1.67.93-2.68.93-.17 0-.33-.01-.49-.03.95 1.53 2.62 2.64 4.51 2.64 5.41 0 8.37-4.48 8.37-8.37l-.01-.38C21.1 7.63 21.85 6.86 22.46 6z" /></svg>
+          </a>
+        </div>
+      </div>
+    </div>
+  </footer>
+
+  <script src="scripts.js"></script>
+</body>
+</html>

--- a/scripts.js
+++ b/scripts.js
@@ -1,0 +1,24 @@
+const nav = document.getElementById('mainNav');
+const menuToggle = document.getElementById('menuToggle');
+const yearEl = document.getElementById('year');
+
+if (menuToggle) {
+  menuToggle.addEventListener('click', () => {
+    const isOpen = nav.classList.toggle('open');
+    menuToggle.setAttribute('aria-expanded', String(isOpen));
+  });
+}
+
+if (yearEl) {
+  yearEl.textContent = new Date().getFullYear();
+}
+
+const navLinks = nav?.querySelectorAll('a[href^="#"]');
+navLinks?.forEach((link) => {
+  link.addEventListener('click', () => {
+    if (nav.classList.contains('open')) {
+      nav.classList.remove('open');
+      menuToggle?.setAttribute('aria-expanded', 'false');
+    }
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,670 @@
+:root {
+  --bg: #020617;
+  --bg-alt: #0b1222;
+  --surface: rgba(15, 23, 42, 0.85);
+  --surface-alt: rgba(30, 41, 59, 0.8);
+  --accent: #38bdf8;
+  --accent-strong: #0ea5e9;
+  --accent-soft: rgba(56, 189, 248, 0.1);
+  --text: #e2e8f0;
+  --text-muted: #94a3b8;
+  --border: rgba(148, 163, 184, 0.15);
+  --radius-lg: 24px;
+  --radius-md: 16px;
+  --radius-sm: 12px;
+  --shadow-lg: 0 40px 80px rgba(2, 6, 23, 0.45);
+  --shadow-md: 0 20px 40px rgba(2, 6, 23, 0.35);
+  --shadow-sm: 0 12px 24px rgba(2, 6, 23, 0.25);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  scroll-behavior: smooth;
+}
+
+body {
+  margin: 0;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+  background: radial-gradient(circle at top, rgba(14, 165, 233, 0.08), rgba(2, 6, 23, 1) 55%),
+    linear-gradient(180deg, rgba(2, 6, 23, 1) 0%, rgba(15, 23, 42, 1) 60%, rgba(2, 6, 23, 1) 100%);
+  color: var(--text);
+  line-height: 1.6;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.container {
+  width: min(1120px, 92vw);
+  margin: 0 auto;
+}
+
+.top-bar {
+  position: sticky;
+  top: 0;
+  z-index: 1000;
+  backdrop-filter: blur(18px);
+  background: rgba(2, 6, 23, 0.8);
+  border-bottom: 1px solid var(--border);
+}
+
+.top-bar .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.1rem 0;
+}
+
+.logo {
+  font-family: "Space Grotesk", sans-serif;
+  font-weight: 700;
+  font-size: 1.4rem;
+  color: var(--text);
+  letter-spacing: 0.02em;
+}
+
+.logo span {
+  color: var(--accent);
+}
+
+.nav {
+  display: flex;
+  gap: 1.5rem;
+  align-items: center;
+}
+
+.nav a {
+  color: var(--text-muted);
+  font-weight: 500;
+  transition: color 0.2s ease;
+}
+
+.nav a:hover,
+.nav a:focus {
+  color: var(--text);
+}
+
+.nav .cta-link {
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  padding: 0.35rem 0.8rem;
+  border-radius: 999px;
+}
+
+.menu-toggle {
+  background: none;
+  border: none;
+  display: none;
+  flex-direction: column;
+  gap: 5px;
+  cursor: pointer;
+}
+
+.menu-toggle span {
+  width: 22px;
+  height: 2px;
+  background: var(--text);
+  display: block;
+}
+
+.hero {
+  padding: 7rem 0 5rem;
+}
+
+.hero-content {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: center;
+}
+
+.hero-copy h1 {
+  font-size: clamp(2.5rem, 6vw, 3.8rem);
+  line-height: 1.1;
+  margin-bottom: 1rem;
+}
+
+.hero-copy p {
+  max-width: 540px;
+  font-size: 1.1rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  background: var(--accent-soft);
+  color: var(--accent);
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.hero-actions {
+  display: flex;
+  gap: 1rem;
+  margin: 2rem 0 2.5rem;
+}
+
+.btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 12px;
+  padding: 0.85rem 1.8rem;
+  font-weight: 600;
+  border: 1px solid transparent;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.btn.primary {
+  background: linear-gradient(135deg, var(--accent) 0%, var(--accent-strong) 100%);
+  color: #020617;
+  box-shadow: var(--shadow-md);
+}
+
+.btn.ghost {
+  background: transparent;
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.btn:hover,
+.btn:focus {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-lg);
+}
+
+.hero-stats {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+
+.hero-stats strong {
+  font-size: 1.8rem;
+  color: var(--accent);
+}
+
+.hero-visual {
+  display: grid;
+  gap: 1.5rem;
+}
+
+.glass-card {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-lg);
+  padding: 1.6rem;
+  box-shadow: var(--shadow-lg);
+  backdrop-filter: blur(16px);
+}
+
+.glass-card header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 1rem;
+}
+
+.glass-card h3 {
+  margin: 0;
+}
+
+.glass-card.report .chart {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  align-items: end;
+  gap: 0.9rem;
+  height: 150px;
+  margin-bottom: 1.2rem;
+}
+
+.glass-card.report .bar {
+  background: linear-gradient(180deg, var(--accent) 0%, rgba(56, 189, 248, 0.2) 100%);
+  border-radius: 12px 12px 4px 4px;
+}
+
+.report-metrics {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.report-metrics li {
+  display: flex;
+  justify-content: space-between;
+  color: var(--text-muted);
+}
+
+.glass-card.lesson p {
+  color: var(--text-muted);
+  margin: 0 0 1rem;
+}
+
+.link {
+  color: var(--accent);
+  font-weight: 600;
+}
+
+.status {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+}
+
+.status.good {
+  background: linear-gradient(135deg, #34d399, #22c55e);
+  box-shadow: 0 0 0 4px rgba(34, 197, 94, 0.15);
+}
+
+.chip {
+  display: inline-flex;
+  align-items: center;
+  background: rgba(56, 189, 248, 0.16);
+  color: var(--accent);
+  border-radius: 999px;
+  padding: 0.3rem 0.8rem;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.section {
+  padding: 5rem 0;
+}
+
+.section h2 {
+  font-size: clamp(2rem, 4vw, 2.8rem);
+  margin-top: 0;
+}
+
+.section p {
+  color: var(--text-muted);
+}
+
+.grid.two-col {
+  display: grid;
+  gap: 3rem;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  align-items: start;
+}
+
+.grid.three-col {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.eyebrow {
+  font-size: 0.9rem;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--accent);
+  display: block;
+  margin-bottom: 1rem;
+}
+
+.feature-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 3rem;
+}
+
+.feature-grid article {
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 1.8rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.highlight {
+  background: radial-gradient(circle at top right, rgba(14, 165, 233, 0.15), transparent 55%);
+}
+
+.highlight-visual .glass-card {
+  width: min(360px, 100%);
+}
+
+.checklist {
+  list-style: none;
+  padding: 0;
+  margin-top: 1.8rem;
+  display: grid;
+  gap: 0.8rem;
+}
+
+.checklist li::before {
+  content: "✔";
+  color: var(--accent);
+  margin-right: 0.8rem;
+}
+
+.stats {
+  background: rgba(15, 23, 42, 0.6);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+
+.stats article {
+  text-align: center;
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.stats strong {
+  font-size: 2.4rem;
+  color: var(--accent);
+}
+
+.pricing-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 3rem;
+}
+
+.plan {
+  position: relative;
+  background: var(--surface-alt);
+  border-radius: var(--radius-md);
+  padding: 2.2rem 2rem;
+  border: 1px solid var(--border);
+  box-shadow: var(--shadow-sm);
+}
+
+.plan ul {
+  list-style: none;
+  padding: 0;
+  margin: 1.5rem 0 2rem;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.plan ul li::before {
+  content: "▹";
+  color: var(--accent);
+  margin-right: 0.6rem;
+}
+
+.plan .price {
+  font-size: 2.4rem;
+  font-weight: 700;
+  margin: 0.6rem 0;
+}
+
+.plan .price span {
+  font-size: 1rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.plan .subtitle {
+  color: var(--text-muted);
+  margin: 0;
+}
+
+.plan.featured {
+  background: linear-gradient(150deg, rgba(56, 189, 248, 0.12), rgba(14, 165, 233, 0.08));
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  box-shadow: var(--shadow-md);
+}
+
+.plan .badge {
+  position: absolute;
+  top: 1.4rem;
+  right: 1.4rem;
+}
+
+.timeline {
+  display: grid;
+  gap: 1.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 3rem;
+}
+
+.timeline article {
+  background: var(--surface-alt);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  padding: 1.8rem;
+}
+
+.timeline article span {
+  display: inline-block;
+  margin-top: 1rem;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  letter-spacing: 0.05em;
+}
+
+.testimonial-grid {
+  display: grid;
+  gap: 2rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  margin-top: 3rem;
+}
+
+.testimonial-grid figure {
+  margin: 0;
+  background: var(--surface-alt);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 2rem;
+  box-shadow: var(--shadow-sm);
+}
+
+.testimonial-grid blockquote {
+  margin: 0 0 1.5rem;
+  font-size: 1.05rem;
+  font-weight: 500;
+}
+
+.testimonial-grid figcaption span {
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.cta {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.18), rgba(8, 145, 178, 0.1));
+  border-top: 1px solid rgba(56, 189, 248, 0.2);
+  border-bottom: 1px solid rgba(56, 189, 248, 0.2);
+}
+
+.demo-form {
+  background: rgba(2, 6, 23, 0.7);
+  border-radius: var(--radius-md);
+  border: 1px solid var(--border);
+  padding: 2rem;
+  box-shadow: var(--shadow-md);
+  display: grid;
+  gap: 1rem;
+}
+
+.demo-form label span {
+  display: block;
+  margin-bottom: 0.35rem;
+  font-weight: 600;
+  color: var(--text);
+}
+
+.demo-form input,
+.demo-form select,
+.demo-form textarea {
+  width: 100%;
+  border-radius: 10px;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text);
+  padding: 0.8rem 1rem;
+  font-size: 1rem;
+  font-family: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.demo-form input:focus,
+.demo-form select:focus,
+.demo-form textarea:focus {
+  outline: none;
+  border-color: rgba(56, 189, 248, 0.7);
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
+.demo-form textarea {
+  resize: vertical;
+}
+
+.form-note {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+  text-align: center;
+}
+
+.footer {
+  padding: 4rem 0 2.5rem;
+  background: rgba(2, 6, 23, 0.95);
+  border-top: 1px solid var(--border);
+}
+
+.footer .container {
+  display: grid;
+  gap: 3rem;
+}
+
+.footer-brand p {
+  color: var(--text-muted);
+  max-width: 320px;
+}
+
+.footer-links {
+  display: grid;
+  gap: 2.5rem;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+}
+
+.footer-links h4 {
+  margin: 0 0 1rem;
+}
+
+.footer-links ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.6rem;
+}
+
+.footer-links a {
+  color: var(--text-muted);
+}
+
+.footer-links a:hover {
+  color: var(--text);
+}
+
+.footer-bottom {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+  color: var(--text-muted);
+}
+
+.socials {
+  display: flex;
+  gap: 1rem;
+}
+
+.socials svg {
+  width: 22px;
+  height: 22px;
+  fill: var(--text-muted);
+  transition: fill 0.2s ease;
+}
+
+.socials a:hover svg {
+  fill: var(--accent);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  border: 0;
+}
+
+@media (max-width: 840px) {
+  .nav {
+    position: fixed;
+    inset: 70px 1.5rem auto;
+    background: rgba(2, 6, 23, 0.98);
+    border: 1px solid var(--border);
+    border-radius: var(--radius-md);
+    padding: 1.5rem;
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+    transform: translateY(-20px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .nav.open {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+  }
+
+  .nav .cta-link {
+    text-align: center;
+  }
+
+  .menu-toggle {
+    display: inline-flex;
+  }
+}
+
+@media (max-width: 640px) {
+  .hero {
+    padding-top: 6rem;
+  }
+
+  .hero-actions {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  .footer-bottom {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}


### PR DESCRIPTION
## Summary
- build a responsive single-page marketing site for SentinelSpark with hero, features, pricing, and roadmap sections
- style the experience with a modern glassmorphism-inspired dark theme and mobile navigation
- add lightweight interactivity for the mobile menu and dynamic copyright year

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e0ea28abfc8325b9c4690bf32fd683