### PR TITLE
Add accessible platform tab UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -118,31 +118,78 @@
       <div class="container">
         <span class="eyebrow">The Platform</span>
         <h2>Everything you need to build a human firewall.</h2>
-        <div class="feature-grid">
-          <article>
-            <h3>Phishing Simulations</h3>
-            <p>Pick from a library of templates or generate new ones with AI. Schedule sends, target teams, and track every action in real time.</p>
-          </article>
-          <article>
-            <h3>Instant Coaching Pages</h3>
-            <p>Employees who fall for a test are redirected to a friendly recap that highlights the clues they missed and reinforces best practices.</p>
-          </article>
-          <article>
-            <h3>Microlearning Library</h3>
-            <p>12 gamified lessons covering phishing, MFA, password hygiene, social engineering, and more—each under five minutes.</p>
-          </article>
-          <article>
-            <h3>Automated Reporting</h3>
-            <p>Live dashboards surface risky departments, trending threats, and improvements over time. Export PDF or CSV in one click.</p>
-          </article>
-          <article>
-            <h3>MSP Mode</h3>
-            <p>Manage multiple client environments with isolated data, white-labeled branding, and consolidated health scores.</p>
-          </article>
-          <article>
-            <h3>Compliance Ready</h3>
-            <p>Audit trails, completion certificates, and policy acknowledgements built in for SOC 2, ISO 27001, and more.</p>
-          </article>
+        <div class="platform-tabs" role="tablist" aria-label="Platform feature categories">
+          <button
+            class="tab-button is-active"
+            type="button"
+            role="tab"
+            aria-selected="true"
+            id="tab-simulations"
+            aria-controls="panel-simulations"
+            tabindex="0"
+          >
+            Simulations &amp; Coaching
+          </button>
+          <button
+            class="tab-button"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            id="tab-learning"
+            aria-controls="panel-learning"
+            tabindex="-1"
+          >
+            Learning &amp; Insights
+          </button>
+          <button
+            class="tab-button"
+            type="button"
+            role="tab"
+            aria-selected="false"
+            id="tab-automation"
+            aria-controls="panel-automation"
+            tabindex="-1"
+          >
+            Scale &amp; Compliance
+          </button>
+        </div>
+        <div class="tab-panels">
+          <div class="panel is-active" role="tabpanel" id="panel-simulations" aria-labelledby="tab-simulations">
+            <div class="feature-grid">
+              <article>
+                <h3>Phishing Simulations</h3>
+                <p>Pick from a library of templates or generate new ones with AI. Schedule sends, target teams, and track every action in real time.</p>
+              </article>
+              <article>
+                <h3>Instant Coaching Pages</h3>
+                <p>Employees who fall for a test are redirected to a friendly recap that highlights the clues they missed and reinforces best practices.</p>
+              </article>
+            </div>
+          </div>
+          <div class="panel" role="tabpanel" id="panel-learning" aria-labelledby="tab-learning" hidden>
+            <div class="feature-grid">
+              <article>
+                <h3>Microlearning Library</h3>
+                <p>12 gamified lessons covering phishing, MFA, password hygiene, social engineering, and more—each under five minutes.</p>
+              </article>
+              <article>
+                <h3>Automated Reporting</h3>
+                <p>Live dashboards surface risky departments, trending threats, and improvements over time. Export PDF or CSV in one click.</p>
+              </article>
+            </div>
+          </div>
+          <div class="panel" role="tabpanel" id="panel-automation" aria-labelledby="tab-automation" hidden>
+            <div class="feature-grid">
+              <article>
+                <h3>MSP Mode</h3>
+                <p>Manage multiple client environments with isolated data, white-labeled branding, and consolidated health scores.</p>
+              </article>
+              <article>
+                <h3>Compliance Ready</h3>
+                <p>Audit trails, completion certificates, and policy acknowledgements built in for SOC 2, ISO 27001, and more.</p>
+              </article>
+            </div>
+          </div>
         </div>
       </div>
     </section>

--- a/scripts.js
+++ b/scripts.js
@@ -22,3 +22,90 @@ navLinks?.forEach((link) => {
     }
   });
 });
+
+const platformTabs = document.querySelector('.platform-tabs');
+const tabButtons = platformTabs ? Array.from(platformTabs.querySelectorAll('.tab-button')) : [];
+
+const activateTab = (button, { focus = false } = {}) => {
+  const targetId = button.getAttribute('aria-controls');
+  if (!targetId) return;
+
+  const targetPanel = document.getElementById(targetId);
+  if (!targetPanel) return;
+
+  tabButtons.forEach((tab) => {
+    const controlsId = tab.getAttribute('aria-controls');
+    const panel = controlsId ? document.getElementById(controlsId) : null;
+    const isActive = tab === button;
+
+    tab.classList.toggle('is-active', isActive);
+    tab.setAttribute('aria-selected', String(isActive));
+    tab.setAttribute('tabindex', isActive ? '0' : '-1');
+
+    if (panel) {
+      panel.classList.toggle('is-active', isActive);
+      if (isActive) {
+        panel.removeAttribute('hidden');
+      } else {
+        panel.setAttribute('hidden', '');
+      }
+    }
+  });
+
+  if (focus) {
+    button.focus();
+  }
+};
+
+const focusTabByIndex = (index) => {
+  if (!tabButtons.length) return;
+
+  const boundedIndex = ((index % tabButtons.length) + tabButtons.length) % tabButtons.length;
+  const targetTab = tabButtons[boundedIndex];
+  if (targetTab) {
+    activateTab(targetTab, { focus: true });
+  }
+};
+
+if (tabButtons.length) {
+  const defaultTab = tabButtons.find((tab) => tab.getAttribute('aria-selected') === 'true') || tabButtons[0];
+  if (defaultTab) {
+    activateTab(defaultTab);
+  }
+
+  tabButtons.forEach((button, index) => {
+    button.addEventListener('click', () => {
+      activateTab(button, { focus: true });
+    });
+
+    button.addEventListener('keydown', (event) => {
+      switch (event.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+          event.preventDefault();
+          focusTabByIndex(index + 1);
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          event.preventDefault();
+          focusTabByIndex(index - 1);
+          break;
+        case 'Home':
+          event.preventDefault();
+          focusTabByIndex(0);
+          break;
+        case 'End':
+          event.preventDefault();
+          focusTabByIndex(tabButtons.length - 1);
+          break;
+        case ' ':
+        case 'Enter':
+          event.preventDefault();
+          activateTab(button, { focus: true });
+          break;
+        default:
+          break;
+      }
+    });
+  });
+}

--- a/styles.css
+++ b/styles.css
@@ -338,6 +338,51 @@ a {
   box-shadow: var(--shadow-sm);
 }
 
+.platform-tabs {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  margin-top: 2.5rem;
+}
+
+.tab-button {
+  border: 1px solid var(--border);
+  background: var(--surface-alt);
+  color: var(--text-muted);
+  padding: 0.75rem 1.5rem;
+  border-radius: var(--radius-md);
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s ease, color 0.2s ease, background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.tab-button:hover,
+.tab-button:focus-visible {
+  border-color: var(--accent);
+  color: var(--text);
+  outline: none;
+  box-shadow: 0 0 0 3px rgba(56, 189, 248, 0.2);
+}
+
+.tab-button.is-active {
+  background: var(--accent-soft);
+  border-color: var(--accent);
+  color: var(--accent);
+  box-shadow: var(--shadow-sm);
+}
+
+.tab-panels {
+  margin-top: 2.5rem;
+}
+
+.panel {
+  transition: opacity 0.2s ease;
+}
+
+.panel[hidden] {
+  opacity: 0;
+}
+
 .highlight {
   background: radial-gradient(circle at top right, rgba(14, 165, 233, 0.15), transparent 55%);
 }


### PR DESCRIPTION
## Summary
- restructure the platform section into tab panels with labelled buttons and aria relationships
- style the new tab buttons and panels to match the existing aesthetic
- extend the tab script to keep aria state, hidden panels, and tabindex values in sync for keyboard users

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68e10ddff79c832592435e6564a3283f