### PR TITLE
Improve tab keyboard interactions

### DIFF
--- a/scripts.js
+++ b/scripts.js
@@ -22,3 +22,75 @@ navLinks?.forEach((link) => {
     }
   });
 });
+
+const tablists = document.querySelectorAll('[role="tablist"]');
+
+const activateTab = (tab, tabs, { setFocus = true } = {}) => {
+  tabs.forEach((currentTab) => {
+    const controlsId = currentTab.getAttribute('aria-controls');
+    const panel = controlsId ? document.getElementById(controlsId) : null;
+    const isActive = currentTab === tab;
+
+    currentTab.setAttribute('aria-selected', String(isActive));
+    currentTab.setAttribute('tabindex', isActive ? '0' : '-1');
+
+    if (panel) {
+      panel.toggleAttribute('hidden', !isActive);
+    }
+  });
+
+  if (setFocus) {
+    tab.focus();
+  }
+};
+
+tablists.forEach((tablist) => {
+  const tabs = Array.from(tablist.querySelectorAll('[role="tab"]'));
+  if (!tabs.length) return;
+
+  const initialTab =
+    tabs.find((tab) => tab.getAttribute('aria-selected') === 'true') || tabs[0];
+
+  tabs.forEach((tab) => {
+    tab.setAttribute('tabindex', tab === initialTab ? '0' : '-1');
+    tab.addEventListener('click', () => activateTab(tab, tabs));
+  });
+
+  activateTab(initialTab, tabs, { setFocus: false });
+
+  tablist.addEventListener('keydown', (event) => {
+    const { key } = event;
+    if (!['ArrowRight', 'ArrowLeft', 'Home', 'End'].includes(key)) return;
+
+    event.preventDefault();
+
+    const activeElement = document.activeElement;
+    const currentIndex = tabs.indexOf(activeElement);
+    const selectedIndex = tabs.findIndex(
+      (tab) => tab.getAttribute('aria-selected') === 'true'
+    );
+    const activeIndex =
+      currentIndex !== -1 ? currentIndex : selectedIndex !== -1 ? selectedIndex : 0;
+
+    let nextIndex = activeIndex;
+
+    switch (key) {
+      case 'ArrowRight':
+        nextIndex = (activeIndex + 1) % tabs.length;
+        break;
+      case 'ArrowLeft':
+        nextIndex = (activeIndex - 1 + tabs.length) % tabs.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = tabs.length - 1;
+        break;
+      default:
+        break;
+    }
+
+    activateTab(tabs[nextIndex], tabs);
+  });
+});


### PR DESCRIPTION
## Summary
- update tab activation logic to keep tabindex values in sync with the selected tab
- wire up arrow key navigation (plus Home/End shortcuts) so keyboard users can cycle tabs
- toggle associated tab panels with the hidden attribute when selection changes

## Testing
- Not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_b_68e10de64fc8832590dc6ec26f02d1b9